### PR TITLE
Basic support for starters

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To see a full list of options use the `--help` flag:
 
 Options:
       --version  Show version number                                   [boolean]
-  -s, --starter  Choose a starter           [choices: "nextjs", "ts-mui-nextjs"]
+  -s, --starter  Choose a starter           [choices: "nextjs", "ts-nextjs"]
       --help     Show help                                             [boolean]
 ```
 
@@ -26,7 +26,7 @@ Options:
 Use the `--starter` option for specifying a starter. Run the command with the `--help` flag to see a full list of available starters.
 
 ```txt
-npx create-stackbit-app --starter ts-mui-nextjs
+npx create-stackbit-app --starter ts-nextjs
 ```
 
 If no starter option is provided, [the default starter](https://github.com/stackbit-themes/nextjs-starter) is used.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,48 @@
 # create-stackbit-app
 
 Run `npx create-stackbit-app` in your terminal to create a new Stackbit application or add Stackbit into an existing site.
+
+## Usage
+
+To create a new Stackbit project from a starter, run the following command:
+
+```txt
+npx create-stackbit-app [dir]
+```
+
+To see a full list of options use the `--help` flag:
+
+```txt
+> npx create-stackbit-app --help
+
+Options:
+      --version  Show version number                                   [boolean]
+  -s, --starter  Choose a starter           [choices: "nextjs", "ts-mui-nextjs"]
+      --help     Show help                                             [boolean]
+```
+
+### Choosing a Starter
+
+Use the `--starter` option for specifying a starter. Run the command with the `--help` flag to see a full list of available starters.
+
+```txt
+npx create-stackbit-app --starter ts-mui-nextjs
+```
+
+If no starter option is provided, [the default starter](https://github.com/stackbit-themes/nextjs-starter) is used.
+
+### Setting Project Directory
+
+Pass a directory name as the only argument when running the command. For example, if you wanted your directory to be name `my-site`, the command would look something like this:
+
+```txt
+npx create-stackbit-app my-site
+```
+
+If no name is provided, the directory will be `my-stackbit-site-[id]`, where `[id]` is a randomly-generated string used to avoid directory conflicts.
+
+## Adding Stackbit to Existing Projects
+
+The script detects when you may be working with an existing project (it looks for a `package.json` file in the working directory).
+
+If in an existing project, the script asks if you'd like to add Stackbit to the project. Today, this only prints a resource URL. If you choose _no_, the command exits.

--- a/config.js
+++ b/config.js
@@ -1,0 +1,15 @@
+const starters = [
+  {
+    name: "nextjs",
+    repoUrl: "https://github.com/stackbit-themes/nextjs-starter",
+  },
+  {
+    name: "ts-mui-nextjs",
+    repoUrl: "https://github.com/stackbit-themes/ts-mui-nextjs-starter",
+  },
+];
+
+export default {
+  defaults: { dirName: "my-stackbit-site", starter: starters[0] },
+  starters,
+};

--- a/config.js
+++ b/config.js
@@ -4,7 +4,7 @@ const starters = [
     repoUrl: "https://github.com/stackbit-themes/nextjs-starter",
   },
   {
-    name: "ts-mui-nextjs",
+    name: "ts-nextjs",
     repoUrl: "https://github.com/stackbit-themes/ts-mui-nextjs-starter",
   },
 ];

--- a/index.js
+++ b/index.js
@@ -3,11 +3,14 @@
 import chalk from "chalk";
 import { exec } from "child_process";
 import fs from "fs";
+import { nanoid } from "nanoid";
 import path from "path";
 import readline from "readline";
 import util from "util";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
+
+import config from "./config.js";
 
 /* --- Helpers --- */
 
@@ -26,21 +29,41 @@ function prompt(question, defaultAnswer) {
 
 /* --- Parse CLI Arguments */
 
-const args = yargs(hideBin(process.argv)).parse();
+const args = yargs(hideBin(process.argv))
+  .option("starter", {
+    alias: "s",
+    describe: "Choose a starter",
+    choices: config.starters.map((s) => s.name),
+  })
+  .help()
+  .parse();
+
+/* --- References --- */
+
+const starter = config.starters.find(
+  (s) => s.name === (args.starter ?? config.defaults.starter.name)
+);
+const dirName =
+  args._[0] ?? `${config.defaults.dirName}-${nanoid(8).toLowerCase()}`;
 
 /* --- New Project --- */
 
 async function cloneStarter() {
   // Clone repo
-  const projectName = args._[0] ?? "my-stackbit-site";
-  const repoUrl = `https://github.com/stackbit/nextjs-starter`;
-  const cloneCommand = `git clone --depth=1 ${repoUrl} ${projectName}`;
-  console.log(`\nCloning into ${projectName} ...`);
+  const cloneCommand = `git clone --depth=1 ${starter.repoUrl} ${dirName}`;
+  console.log(`\nCreating new project in ${dirName} ...`);
   await run(cloneCommand);
 
   // Install dependencies
   console.log(`Installing dependencies ...`);
-  await run(`cd ${projectName} && npm install`);
+  await run(`cd ${dirName} && npm install`);
+
+  // Set up git
+  console.log(`Setting up Git ...`);
+  await run(`rm -rf ${dirName}/.git`);
+  await run(
+    `cd ${dirName} && git init && git add . && git commit -m "New Stackbit project"`
+  );
 
   // Output next steps:
   console.log(`
@@ -48,7 +71,7 @@ async function cloneStarter() {
 
 Follow the instructions for getting Started here:
 
-    https://github.com/stackbit/nextjs-starter#getting-started
+    ${starter.repoUrl}#readme
   `);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.0.0",
+        "nanoid": "^3.3.4",
         "yargs": "^17.3.1"
       },
       "bin": {
@@ -102,6 +103,17 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/require-directory": {
@@ -247,6 +259,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
+    "nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-stackbit-app",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "create-stackbit-app",
-      "version": "0.0.3",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "type": "module",
   "dependencies": {
     "chalk": "^5.0.0",
+    "nanoid": "^3.3.4",
     "yargs": "^17.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-stackbit-app",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Create a new Stackbit site, or add Stackbit to an existing site.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This provides some super simple support for starters. 

It also is a little safer in avoiding directory conflicts by appending a random string when using the default directory name.

Updated usage details in the README. 

### Testing

To test, checkout this branch, then run:

```txt
npm link
cd /some/empty/test/directory
create-stackbit-app ...
```