### PR TITLE
v0.1.1: Examples monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npx create-stackbit-app --starter ts-nextjs
 
 If no starter option is provided, [the default starter](https://github.com/stackbit-themes/nextjs-starter) is used.
 
-### Starting from an Example
+### Starting from an Example (🧪 Experimental)
 
 Use the `--example` option to start a project from an example. Run the command with the `--help` flag to see a full list of available starters.
 
@@ -42,6 +42,8 @@ npx create-stackbit-app --example algolia-search
 ```
 
 This will create a new project matching the name of the example, unless overridden (see below). [See here for a full list of starters](https://github.com/stackbit-themes/stackbit-examples).
+
+_Note: This is an experimental feature. Please [report issues](https://github.com/stackbit/create-stackbit-app/issues/new)._
 
 ### Setting Project Directory
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ To see a full list of options use the `--help` flag:
 
 Options:
       --version  Show version number                                   [boolean]
-  -s, --starter  Choose a starter           [choices: "nextjs", "ts-nextjs"]
+  -s, --starter  Choose a starter               [choices: "nextjs", "ts-nextjs"]
+  -e, --example  Start from an example
+         [choices: "algolia-search", "dynamic-app", "sb-countdown", "sb-typist"]
       --help     Show help                                             [boolean]
 ```
 
@@ -31,6 +33,16 @@ npx create-stackbit-app --starter ts-nextjs
 
 If no starter option is provided, [the default starter](https://github.com/stackbit-themes/nextjs-starter) is used.
 
+### Starting from an Example
+
+Use the `--example` option to start a project from an example. Run the command with the `--help` flag to see a full list of available starters.
+
+```txt
+npx create-stackbit-app --example algolia-search
+```
+
+This will create a new project matching the name of the example, unless overridden (see below). [See here for a full list of starters](https://github.com/stackbit-themes/stackbit-examples).
+
 ### Setting Project Directory
 
 Pass a directory name as the only argument when running the command. For example, if you wanted your directory to be name `my-site`, the command would look something like this:
@@ -39,7 +51,7 @@ Pass a directory name as the only argument when running the command. For example
 npx create-stackbit-app my-site
 ```
 
-If no name is provided, the directory will be `my-stackbit-site-[id]`, where `[id]` is a randomly-generated string used to avoid directory conflicts.
+If no name is provided, the directory will be `my-stackbit-site` for starters or will match the name of the example if starting from an example. If the directory already exists, a timestamp value will be appended to the directory name to ensure uniqueness.
 
 ## Adding Stackbit to Existing Projects
 

--- a/config.js
+++ b/config.js
@@ -9,7 +9,13 @@ const starters = [
   },
 ];
 
+const examples = {
+  repoUrl: "https://github.com/stackbit-themes/stackbit-examples",
+  directories: ["algolia-search", "dynamic-app", "sb-countdown", "sb-typist"],
+};
+
 export default {
   defaults: { dirName: "my-stackbit-site", starter: starters[0] },
+  examples,
   starters,
 };

--- a/index.js
+++ b/index.js
@@ -133,7 +133,10 @@ async function cloneExample() {
   if (!gitVersionMatch || !gitVersionMatch[0]) {
     console.error(
       `Cannot determine git version, which is required for starting from an example.`,
-      `\nPlease report this to ${chalk.underline("support@stackbit.com")}.`
+      `\nPlease report this:`,
+      chalk.underline(
+        "https://github.com/stackbit/create-stackbit-app/issues/new"
+      )
     );
     process.exit(1);
   }

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
 import chalk from "chalk";
 import { exec } from "child_process";
 import fs from "fs";
-import { nanoid } from "nanoid";
 import path from "path";
 import readline from "readline";
 import util from "util";
@@ -62,10 +61,10 @@ const starter = config.starters.find(
   (s) => s.name === (args.starter ?? config.defaults.starter.name)
 );
 
-const timestamp = new Date().getTime();
+// Current time in seconds.
+const timestamp = Math.round(new Date().getTime() / 1000);
 
-const dirName =
-  args._[0] ?? `${config.defaults.dirName}-${nanoid(8).toLowerCase()}`;
+const dirName = args._[0] ?? `${config.defaults.dirName}-${timestamp}`;
 
 /* --- New Project from Starter --- */
 

--- a/index.js
+++ b/index.js
@@ -26,12 +26,12 @@ function prompt(question, defaultAnswer) {
   });
 }
 
-async function installDependencies() {
+async function installDependencies(dirName) {
   console.log(`Installing dependencies ...`);
   await run(`cd ${dirName} && npm install`);
 }
 
-async function initGit() {
+async function initGit(dirName) {
   console.log(`Setting up Git ...`);
   await run(`rm -rf ${dirName}/.git`);
   await run(
@@ -64,19 +64,20 @@ const starter = config.starters.find(
 // Current time in seconds.
 const timestamp = Math.round(new Date().getTime() / 1000);
 
-const dirName = args._[0] ?? `${config.defaults.dirName}-${timestamp}`;
-
 /* --- New Project from Starter --- */
 
 async function cloneStarter() {
+  // Set references
+  const dirName = args._[0] ?? `${config.defaults.dirName}-${timestamp}`;
+
   // Clone repo
   const cloneCommand = `git clone --depth=1 ${starter.repoUrl} ${dirName}`;
   console.log(`\nCreating new project in ${dirName} ...`);
   await run(cloneCommand);
 
   // Project Setup
-  await installDependencies();
-  await initGit();
+  await installDependencies(dirName);
+  await initGit(dirName);
 
   // Output next steps:
   console.log(`
@@ -91,7 +92,8 @@ Follow the instructions for getting Started here:
 /* --- New Project from Example --- */
 
 async function cloneExample() {
-  const tmpDir = `examples-sparse-${timestamp}`;
+  const dirName = args._[0] ?? `${args.example}-${timestamp}`;
+  const tmpDir = `__tmp${timestamp}__`;
   console.log(`\nCreating new project in ${dirName} ...`);
 
   try {
@@ -107,8 +109,8 @@ async function cloneExample() {
     await run(`rm -rf ${tmpDir}`);
 
     // Project Setup
-    await installDependencies();
-    await initGit();
+    await installDependencies(dirName);
+    await initGit(dirName);
   } catch (err) {
     console.error(err);
     if (fs.existsSync(dirName)) await run(`rm -rf ${dirName}`);

--- a/index.js
+++ b/index.js
@@ -26,6 +26,12 @@ function prompt(question, defaultAnswer) {
   });
 }
 
+function getDirName(defaultDirName) {
+  let dirName = args._[0] ?? defaultDirName;
+  if (fs.existsSync(dirName)) dirName += `-${timestamp}`;
+  return dirName;
+}
+
 async function installDependencies(dirName) {
   console.log(`Installing dependencies ...`);
   await run(`cd ${dirName} && npm install`);
@@ -68,7 +74,7 @@ const timestamp = Math.round(new Date().getTime() / 1000);
 
 async function cloneStarter() {
   // Set references
-  const dirName = args._[0] ?? `${config.defaults.dirName}-${timestamp}`;
+  const dirName = getDirName(config.defaults.dirName);
 
   // Clone repo
   const cloneCommand = `git clone --depth=1 ${starter.repoUrl} ${dirName}`;
@@ -92,7 +98,7 @@ Follow the instructions for getting Started here:
 /* --- New Project from Example --- */
 
 async function cloneExample() {
-  const dirName = args._[0] ?? `${args.example}-${timestamp}`;
+  const dirName = getDirName(args.example);
   const tmpDir = `__tmp${timestamp}__`;
   console.log(`\nCreating new project in ${dirName} ...`);
 

--- a/index.js
+++ b/index.js
@@ -95,20 +95,27 @@ async function cloneExample() {
   const tmpDir = `examples-sparse-${timestamp}`;
   console.log(`\nCreating new project in ${dirName} ...`);
 
-  // Sparse clone the monorepo.
-  await run(
-    `git clone --depth 1 --filter=blob:none --sparse ${config.examples.repoUrl} ${tmpDir}`
-  );
-  // Checkout just the example dir.
-  await run(`cd ${tmpDir} && git sparse-checkout set ${args.example}`);
-  // Copy out into a new directory within current working directory.
-  await run(`cp -R ${tmpDir}/${args.example} ${dirName}`);
-  // Delete the clone.
-  await run(`rm -rf ${tmpDir}`);
+  try {
+    // Sparse clone the monorepo.
+    await run(
+      `git clone --depth 1 --filter=blob:none --sparse ${config.examples.repoUrl} ${tmpDir}`
+    );
+    // Checkout just the example dir.
+    await run(`cd ${tmpDir} && git sparse-checkout set ${args.example}`);
+    // Copy out into a new directory within current working directory.
+    await run(`cp -R ${tmpDir}/${args.example} ${dirName}`);
+    // Delete the clone.
+    await run(`rm -rf ${tmpDir}`);
 
-  // Project Setup
-  await installDependencies();
-  await initGit();
+    // Project Setup
+    await installDependencies();
+    await initGit();
+  } catch (err) {
+    console.error(err);
+    if (fs.existsSync(dirName)) await run(`rm -rf ${dirName}`);
+    if (fs.existsSync(tmpDir)) await run(`rm -rf ${tmpDir}`);
+    process.exit(1);
+  }
 
   // Output next steps:
   console.log(`

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.0.0",
-        "nanoid": "^3.3.4",
         "yargs": "^17.3.1"
       },
       "bin": {
@@ -103,17 +102,6 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/require-directory": {
@@ -259,11 +247,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-    },
-    "nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-stackbit-app",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "create-stackbit-app",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-stackbit-app",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Create a new Stackbit site, or add Stackbit to an existing site.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "type": "module",
   "dependencies": {
     "chalk": "^5.0.0",
-    "nanoid": "^3.3.4",
     "yargs": "^17.3.1"
   }
 }


### PR DESCRIPTION
Big new feature is support for examples from [the monorepo](https://github.com/stackbit-themes/stackbit-examples). This works by doing a sparse clone, then checking out and moving some things around. It's not perfect, but it's a good start and we'll adjust as folks use this.

This also now appends a timestamp for unique dir names **only if it needs to**.

### Testing

Because [this is a newer Git feature](https://stackoverflow.com/a/52269934/2241124), we probably want to:

- Test on a Windows machine (who can do this?)
- Put in a check for the proper Git version and require an update.

Alternatively, we can release this as "experimental" to gather feedback and adjust. This is the simpler approach which would get this released sooner and help collect feedback on bugs before deciding the best approach.

---

Fixes #4 
Fixes #6 
Fixes #10 
