### PR TITLE
Remove contentful tutorial

### DIFF
--- a/config.js
+++ b/config.js
@@ -37,6 +37,8 @@ const examples = {
     "onboarding-webapp",
     "sveltekit-contentful",
     "tutorial-contentful",
+    "tutorial-nextjs-contentful",
+    "tutorial-nextjs-files",
   ],
 };
 

--- a/config.js
+++ b/config.js
@@ -36,7 +36,6 @@ const examples = {
     "ninetailed-personalization",
     "onboarding-webapp",
     "sveltekit-contentful",
-    "tutorial-contentful",
     "tutorial-nextjs-contentful",
     "tutorial-nextjs-files",
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-stackbit-app",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "create-stackbit-app",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-stackbit-app",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "create-stackbit-app",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-stackbit-app",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Create a new Stackbit site, or add Stackbit to an existing site.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-stackbit-app",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Create a new Stackbit site, or add Stackbit to an existing site.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Relies on #18. And should also not be published until the old Contentful tutorial is removed from the docs site (or at the same time).